### PR TITLE
Fix checking convert success

### DIFF
--- a/lib/libreconv.rb
+++ b/lib/libreconv.rb
@@ -83,7 +83,7 @@ module Libreconv
           *command,
           unsetenv_others: true
         )
-        unless status.success? && error == ''
+        if !status.success?
           raise ConversionFailedError,
                 "Conversion failed! Output: #{output.strip.inspect}, " \
                 "Error: #{error.strip.inspect}"


### PR DESCRIPTION
Don't look at the error string, as deprecation warnings will also come
through on this string. Only look at if the command was successful.